### PR TITLE
Feature: Add machine translations button to documentation

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -20,8 +20,7 @@ template:
             {
               pageLanguage: 'en',
               includedLanguages: 'es,fr,de,zh-CN',
-              layout: google.translate.TranslateElement.InlineLayout.SIMPLE,
-              autoDisplay: false
+              layout: google.translate.TranslateElement.InlineLayout.SIMPLE
             },
             'dropdown-translate'
           );

--- a/pkgdown/extra.scss
+++ b/pkgdown/extra.scss
@@ -7,6 +7,11 @@ body:has(> div.skiptranslate:not([style*="display:"]) > iframe) nav {
   top: 40px;
 }
 
+// disable default translate glow effect
+iframe.skiptranslate {
+  box-shadow: none;
+}
+
 // hide the original dropdown menu from pkgdown
 #dropdown-translate + .dropdown-menu {
   display: none;


### PR DESCRIPTION
I wanted this to be a bit more cohesively integrated into the page so I spent a bit of time trying to shoehorn the google translate gadget into something that could sit within the docs navbar. The approach is a little messy, but the results are nice.

Just to outline the approach:

- Add a custom dropdown menu to the pkgdown config. This dropdown menu will be co-opted by the google translate gadget, so we leave the menu items blank. An empty menu would still be shown, so we hide it via css.
- Override the theming for the google translate gadget so that it is invisible (but still clickable)
- Position the gadget above the navbar icon via css and give it z-priority so it receives clicks

There's also some css in there to reposition the navbar when the translate banner is displayed. Without it, pkgdown's default navbar styling will leave it at the top and covered by the translate banner. Unfortunately we can't style the language dropdown because it's an iframe

With all that, this is what we get

### navbar translate button

<img width="487" height="260" alt="image" src="https://github.com/user-attachments/assets/109d6daf-6fc4-494a-a868-a7698428a6bd" />

### navbar translate button dropdown

<img width="487" height="260" alt="image" src="https://github.com/user-attachments/assets/42aae130-074b-4cc9-ae9e-6e2ce0cc6cae" />

### page with translation banner

<img width="492" height="336" alt="image" src="https://github.com/user-attachments/assets/077cfec5-16ea-4319-b5ad-9c03c90212ef" />
