### PR TITLE
Use path without file://

### DIFF
--- a/R/class_pkg.R
+++ b/R/class_pkg.R
@@ -177,7 +177,7 @@ random_repo <- function(..., path = tempfile("repo")) {
   )
   writeLines(dcf, packages_path)
 
-  repos <- paste0("file://", normalizePath(path))
+  repos <- normalizePath(path, winslash = "/")
   names(repos) <- paste0(packageName(), "-generated")
 
   repos


### PR DESCRIPTION
On my windows machine I cant' `create.dir(random_repo(n=1), recursive = TRUE)` if there is a `file://` prefix on the path. 
This PR removes it and uses the forward slash for Windows as I found that is what `file.path()` uses and creates less problems on windows. 

This function is not covered by any tests, let me know if I add some tests for it